### PR TITLE
Implement DenseArray and Strided Interface

### DIFF
--- a/src/PtrArrays.jl
+++ b/src/PtrArrays.jl
@@ -88,8 +88,8 @@ Base.@propagate_inbounds function Base.setindex!(p::PtrArray, v, i::Int)
 end
 
 # Strided array interface https://docs.julialang.org/en/v1/manual/interfaces/#man-interface-strided-arrays
-Base.strides(p::PtrArray) = Base.size_to_strides(1, size(p)...)
 Base.unsafe_convert(::Type{Ptr{T}}, p::PtrArray{T}) where T = p.ptr
 Base.elsize(::Type{P}) where P<:PtrArray = sizeof(eltype(P))
+Base.strides(p::PtrArray) = (1, accumulate(*, Base.front(size(p)))...)
 
 end

--- a/src/PtrArrays.jl
+++ b/src/PtrArrays.jl
@@ -9,7 +9,7 @@ Wrap a pointer in an `DenseArray` interface conformant `PtrArray` using the stan
 Julia memory order.
 
 Validates that `dims` are non-negative and don't overflow when multiplied if `check_dims` is
-true. Wierd things might happen if you set `check_dims=false` and use nagative or
+true. Weird things might happen if you set `check_dims=false` and use negative or
 overflowing `dims`.
 
 !!! note
@@ -71,7 +71,7 @@ end
 Free the memory allocated by a [`PtrArray`](@ref) allocated by [`malloc`](@ref).
 
 It is only safe to call this function on `PtrArray`s returned by `malloc`, and it is unsafe
-to perform any opperation on a `PtrArray` after calling `free`.
+to perform any operation on a `PtrArray` after calling `free`.
 """
 free(p::PtrArray) = Libc.free(p.ptr)
 

--- a/src/PtrArrays.jl
+++ b/src/PtrArrays.jl
@@ -88,7 +88,6 @@ Base.@propagate_inbounds function Base.setindex!(p::PtrArray, v, i::Int)
 end
 
 # Strided array interface https://docs.julialang.org/en/v1/manual/interfaces/#man-interface-strided-arrays
-Base.strides(p::PtrArray) = Base.size_to_strides(1, size(p)...)
 Base.unsafe_convert(::Type{Ptr{T}}, p::PtrArray{T}) where T = p.ptr
 Base.elsize(::Type{P}) where P<:PtrArray = sizeof(eltype(P))
 

--- a/src/PtrArrays.jl
+++ b/src/PtrArrays.jl
@@ -88,8 +88,8 @@ Base.@propagate_inbounds function Base.setindex!(p::PtrArray, v, i::Int)
 end
 
 # Strided array interface https://docs.julialang.org/en/v1/manual/interfaces/#man-interface-strided-arrays
+Base.strides(p::PtrArray) = Base.size_to_strides(1, size(p)...)
 Base.unsafe_convert(::Type{Ptr{T}}, p::PtrArray{T}) where T = p.ptr
 Base.elsize(::Type{P}) where P<:PtrArray = sizeof(eltype(P))
-Base.strides(p::PtrArray) = (1, accumulate(*, Base.front(size(p)))...)
 
 end

--- a/src/PtrArrays.jl
+++ b/src/PtrArrays.jl
@@ -3,9 +3,9 @@ module PtrArrays
 export malloc, free, PtrArray
 
 """
-    PtrArray(ptr::Ptr{T}, dims::Int...; check_dims=true) <: AbstractArray{T}
+    PtrArray(ptr::Ptr{T}, dims::Int...; check_dims=true) <: DenseArray{T}
 
-Wrap a pointer in an `AbstractArray` interface conformant `PtrArray` using the standard
+Wrap a pointer in an `DenseArray` interface conformant `PtrArray` using the standard
 Julia memory order.
 
 Validates that `dims` are non-negative and don't overflow when multiplied if `check_dims` is
@@ -20,7 +20,7 @@ overflowing `dims`.
 
 see also [`malloc`](@ref), [`free`](@ref)
 """
-struct PtrArray{T, N} <: AbstractArray{T, N}
+struct PtrArray{T, N} <: DenseArray{T, N}
     ptr::Ptr{T}
     size::NTuple{N, Int}
     function PtrArray(ptr::Ptr{T}, dims::Vararg{Int, N}; check_dims=true) where {T, N}
@@ -86,5 +86,10 @@ Base.@propagate_inbounds function Base.setindex!(p::PtrArray, v, i::Int)
     unsafe_store!(p.ptr, v, i)
     p
 end
+
+# Strided array interface
+Base.strides(p::PtrArray) = Base.size_to_strides(1, size(p)...)
+Base.unsafe_convert(::Type{Ptr{T}}, A::PtrArray{T}) where {T} = p.ptr
+Base.elsize(::Type{P}) where {P<:PtrArray} = sizeof(eltype(P))
 
 end

--- a/src/PtrArrays.jl
+++ b/src/PtrArrays.jl
@@ -87,9 +87,9 @@ Base.@propagate_inbounds function Base.setindex!(p::PtrArray, v, i::Int)
     p
 end
 
-# Strided array interface
+# Strided array interface https://docs.julialang.org/en/v1/manual/interfaces/#man-interface-strided-arrays
 Base.strides(p::PtrArray) = Base.size_to_strides(1, size(p)...)
-Base.unsafe_convert(::Type{Ptr{T}}, A::PtrArray{T}) where {T} = p.ptr
-Base.elsize(::Type{P}) where {P<:PtrArray} = sizeof(eltype(P))
+Base.unsafe_convert(::Type{Ptr{T}}, p::PtrArray{T}) where T = p.ptr
+Base.elsize(::Type{P}) where P<:PtrArray = sizeof(eltype(P))
 
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -47,7 +47,7 @@ end
     @test length(z) == 240
     @test size(z) == (4, 6, 10)
     @test strides(z) == (1, 4, 24)
-    @test elsize(z) == sizeof(Int)
+    @test Base.elsize(z) == sizeof(Int)
     @test z isa PtrArray
     @test z isa DenseArray{Int, 3}
     free(z)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -9,7 +9,7 @@ end
 
 @testset "Basics" begin
     x = malloc(Int, 10)
-    @test x isa AbstractVector{Int}
+    @test x isa DenseVector{Int}
     @test x isa PtrArray
 
     x .= 1:10
@@ -25,7 +25,8 @@ end
     y = malloc(Complex{Float64}, 4, 10)
     @test length(y) == 40
     @test size(y) == (4, 10)
-    @test y isa AbstractMatrix{Complex{Float64}}
+    @test strides(y) == (1, 4)
+    @test y isa DenseMatrix{Complex{Float64}}
     @test y isa PtrArray
 
     fill!(y, im)
@@ -39,6 +40,13 @@ end
     @test free(y) === nothing
 
     @test_throws ArgumentError malloc(Vector{Int}, 10)
+    
+    z = malloc(Int, 4, 6, 10)
+    @test length(z) == 240
+    @test size(z) == (4, 6, 10)
+    @test strides(z) == (1, 4, 24)
+    @test z isa PtrArray
+    @test z isa DenseArray{Int, 3}
 end
 
 function f(x, y)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -9,6 +9,7 @@ end
 
 @testset "Basics" begin
     x = malloc(Int, 10)
+    @test x isa AbstractVector{Int}
     @test x isa DenseVector{Int}
     @test x isa PtrArray
 
@@ -40,13 +41,16 @@ end
     @test free(y) === nothing
 
     @test_throws ArgumentError malloc(Vector{Int}, 10)
-    
+
+    # Strided array API
     z = malloc(Int, 4, 6, 10)
     @test length(z) == 240
     @test size(z) == (4, 6, 10)
     @test strides(z) == (1, 4, 24)
+    @test elsize(z) == sizeof(Int)
     @test z isa PtrArray
     @test z isa DenseArray{Int, 3}
+    free(z)
 end
 
 function f(x, y)


### PR DESCRIPTION
This PR changes the supertype of `PtrArray` to `DenseArray`, and implements the necessary interface functions.
This automatically enables the usage of BLAS, and improves the interplay with other packages.

Closes #9 