### PR TITLE
use CheckedSizeProduct.jl for implementing `checked_dims`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -3,7 +3,11 @@ uuid = "43287f4e-b6f4-7ad1-bb20-aadabca52c3d"
 authors = ["Lilith Orion Hafner <lilithhafner@gmail.com> and contributors"]
 version = "1.3.0"
 
+[deps]
+CheckedSizeProduct = "1b2cc9da-92e3-4b71-9788-30fc110eefda"
+
 [compat]
+CheckedSizeProduct = "1"
 julia = "1"
 
 [extras]

--- a/src/PtrArrays.jl
+++ b/src/PtrArrays.jl
@@ -40,14 +40,13 @@ checked_dims(elsize::Int; message) = elsize
 function checked_dims(elsize::Int, d0::Int, d::Int...; message)
     len = checked_size_product((d0, d...))
     ok = len !== nothing
-    local overflow_final
     if ok
-        len, overflow_final = Base.mul_with_overflow(len, elsize)
+        len_final, overflow_final = Base.mul_with_overflow(len, elsize)
+        if !overflow_final
+            return len_final
+        end
     end
-    if !ok || overflow_final
-        throw_invalid_dimensions(message)
-    end
-    len
+    throw_invalid_dimensions(message)
 end
 
 """

--- a/src/PtrArrays.jl
+++ b/src/PtrArrays.jl
@@ -1,5 +1,7 @@
 module PtrArrays
 
+using CheckedSizeProduct: checked_size_product
+
 export malloc, free, PtrArray
 
 """
@@ -29,22 +31,22 @@ struct PtrArray{T, N} <: DenseArray{T, N}
     end
 end
 
+@noinline function throw_invalid_dimensions(message)
+    throw(ArgumentError("invalid $message dimensions"))
+end
+
 # Because Core.checked_dims is buggy 😢
 checked_dims(elsize::Int; message) = elsize
 function checked_dims(elsize::Int, d0::Int, d::Int...; message)
-    overflow = false
-    neg = (d0+1) < 1
-    zero = false # of d0==0 we won't have overflow since we go left to right
-    len = d0
-    for di in d
-        len, o = Base.mul_with_overflow(len, di)
-        zero |= di === 0
-        overflow |= o
-        neg |= (di+1) < 1
+    len = checked_size_product((d0, d...))
+    ok = len !== nothing
+    local overflow_final
+    if ok
+        len, overflow_final = Base.mul_with_overflow(len, elsize)
     end
-    len, o = Base.mul_with_overflow(len, elsize)
-    err = o | neg | overflow & !zero
-    err && throw(ArgumentError("invalid $message dimensions"))
+    if !ok || overflow_final
+        throw_invalid_dimensions(message)
+    end
     len
 end
 


### PR DESCRIPTION
Benefits:

* Better effects.

* Prevent the same logic from being reimplemented several times across the ecosystem.