### PR TITLE
Simplify `checked_dims`, improving its effects, theoretical runtime, and practical runtime for >=3 dims

### DIFF
--- a/src/PtrArrays.jl
+++ b/src/PtrArrays.jl
@@ -31,7 +31,7 @@ end
 
 # Because Core.checked_dims is buggy 😢
 checked_dims(pre_checked::Int; message) = pre_checked
-function checked_dims(pre_checked::Int, d::Int, ds::Int...; message)
+function checked_dims(pre_checked::Int, d::Int, ds::Vararg{Int, N}; message) where N
     d+1 < 1 && throw(ArgumentError("invalid $message dimensions"))
     product, o = Base.mul_with_overflow(pre_checked, d)
     if o

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -94,6 +94,7 @@ end
 @testset "Invalid dimensions" begin
     @test_throws ArgumentError("invalid malloc dimensions") malloc(Int, -10, 10, 0)
     @test_throws ArgumentError("invalid malloc dimensions") malloc(Int, 1000000, 1000000, 1000000, 1000000)
+    @test_throws ArgumentError("invalid malloc dimensions") malloc(Nothing, 1000000, 1000000, 1000000, 1000000)
     words_in_word_size = Sys.WORD_SIZE - Int(log2(sizeof(Int)))
     @test_throws ArgumentError("invalid malloc dimensions") malloc(Int, 2^(words_in_word_size-1))
     @test_throws ArgumentError("invalid malloc dimensions") malloc(Int, 2^(words_in_word_size+1)-1)
@@ -102,9 +103,4 @@ end
     @test_throws ArgumentError("invalid malloc dimensions") malloc(Int, 2^(words_in_word_size))
     @test_throws ArgumentError("invalid malloc dimensions") malloc(UInt128, 2^3, 2^(Sys.WORD_SIZE-5))
     Sys.WORD_SIZE == 64 && @test_throws OutOfMemoryError() malloc(Int, 2^(Sys.WORD_SIZE-5)) # We could actually have enough memory on 32-bit systems
-
-    x = malloc(Nothing, 1000000, 1000000, 1000000, 1000000)
-    @test x[1] === x[end] === x[1, end, 1, end] === nothing
-    @test all(x -> x === nothing, Iterators.take(x, 100))
-    @test all(x -> x === nothing, rand(x, 100))
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -104,7 +104,7 @@ end
     Sys.WORD_SIZE == 64 && @test_throws OutOfMemoryError() malloc(Int, 2^(Sys.WORD_SIZE-5)) # We could actually have enough memory on 32-bit systems
 
     x = malloc(Nothing, 1000000, 1000000, 1000000, 1000000)
-    @test x[begin] === x[end] === x[begin, end, begin, end] === x[978233, 812739, 271782, 184723] === nothing
+    @test x[begin] === x[end] === x[begin, end, begin, end] === nothing
     @test all(isnothing, Iterators.take(x, 100))
     @test all(isnothing, rand(x, 100))
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -104,7 +104,7 @@ end
     Sys.WORD_SIZE == 64 && @test_throws OutOfMemoryError() malloc(Int, 2^(Sys.WORD_SIZE-5)) # We could actually have enough memory on 32-bit systems
 
     x = malloc(Nothing, 1000000, 1000000, 1000000, 1000000)
-    @test x[begin] === x[end] === x[begin, end, begin, end] === nothing
+    @test x[1] === x[end] === x[1, end, 1, end] === nothing
     @test all(isnothing, Iterators.take(x, 100))
     @test all(isnothing, rand(x, 100))
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -87,8 +87,8 @@ end
     @test 0 == @allocated g(Val(2))
     @test 0 == @allocated g(Val(3))
     @test 0 == @allocated g(Val(4))
-    @test 0 == @allocated g(Val(10))
-    @test 0 == @allocated g(Val(15))
+    VERSION >= v"1.11" && @test 0 == @allocated g(Val(10))
+    VERSION >= v"1.11" && @test 0 == @allocated g(Val(15))
 end
 
 @testset "Invalid dimensions" begin

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -84,9 +84,9 @@ end
     @test g(Val(15)) === nothing
     @test 0 == @allocated g(Val(0))
     @test 0 == @allocated g(Val(1))
-    @test 0 == @allocated g(Val(2))
-    @test 0 == @allocated g(Val(3))
-    @test 0 == @allocated g(Val(4))
+    VERSION >= v"1.11" && @test 0 == @allocated g(Val(2))
+    VERSION >= v"1.11" && @test 0 == @allocated g(Val(3))
+    VERSION >= v"1.11" && @test 0 == @allocated g(Val(4))
     VERSION >= v"1.11" && @test 0 == @allocated g(Val(10))
     VERSION >= v"1.11" && @test 0 == @allocated g(Val(15))
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -105,6 +105,6 @@ end
 
     x = malloc(Nothing, 1000000, 1000000, 1000000, 1000000)
     @test x[1] === x[end] === x[1, end, 1, end] === nothing
-    @test all(isnothing, Iterators.take(x, 100))
-    @test all(isnothing, rand(x, 100))
+    @test all(x -> x === nothing, Iterators.take(x, 100))
+    @test all(x -> x === nothing, rand(x, 100))
 end


### PR DESCRIPTION
Test for no allocations at dimensionality up to 15 (above that the use of tuples allocates)
Allow `malloc(Nothing, very_big_dims...)`
